### PR TITLE
Raw list method

### DIFF
--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -69,7 +69,7 @@ class CipApiClient(RestClient):
         currently returns a case or False
         :return:
         """
-        # try:
+        
         case_id, case_version = case_list_entity["interpretation_request_id"].split("-")
         try:
             case = self.get_case(case_id, case_version)


### PR DESCRIPTION
Added a new pair of methods 
1 - to pull out the indivdual elements from the plain interpretation request list endpoint
2 - to retrieve the full case details for each of these elements

Example use case: I want to iterate through the interpretation requests for a cip, or on a particular assembly, and identify the last_statuses of each - does not require migration to full ir object