### PR TITLE
fix(CIPAPI-320): fixed clinical report post

### DIFF
--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -112,7 +112,7 @@ class CipApiClient(RestClient):
         return self.post(url, payload=payload, params=params)
 
     def submit_clinical_report_raw(self, payload, partner_id, analysis_type, report_id, **params):
-        url = self.build_url(self.url_base, self.CR_ENDPOINT, partner_id, analysis_type, report_id)
+        url = self.build_url(self.url_base, self.CR_ENDPOINT, partner_id, analysis_type, report_id) + '/'
         return self.post(url, payload, params=params)
 
     def list_clinical_reports_raw(self, **params):

--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -84,7 +84,7 @@ class CipApiClient(RestClient):
         return self.post(url, payload=payload, params=params)
 
     def file_upload_raw(self, file_path, user, partner_id, report_id, file_type, **params):
-        url = self.build_url(self.url_base, self.FILE_ENDPOINT, partner_id, report_id, file_type)
+        url = self.build_url(self.url_base, self.FILE_ENDPOINT, partner_id, report_id, file_type) + '/'
         files = {'file': open(file_path, 'rb')}
         data = {'user': user}
         return self.post(url, payload=data, files=files, params=params)
@@ -108,7 +108,7 @@ class CipApiClient(RestClient):
         return self.put(url, payload=None, params=params)
 
     def submit_interpreted_genome_raw(self, payload, partner_id, analysis_type, report_id, **params):
-        url = self.build_url(self.url_base, self.IG_ENDPOINT, partner_id, analysis_type, report_id)
+        url = self.build_url(self.url_base, self.IG_ENDPOINT, partner_id, analysis_type, report_id) + '/'
         return self.post(url, payload=payload, params=params)
 
     def submit_clinical_report_raw(self, payload, partner_id, analysis_type, report_id, **params):


### PR DESCRIPTION
<h1>RuntimeError at /api/2/clinical-report/illumina/cancer/ILMN-8-1</h1>
<pre class="exception_value">You called this URL via POST, but the URL doesn't end in a slash and you have APPEND_SLASH set. Django can't redirect to the slash URL while maintaining POST data. Change your form to point to cipapi-gms-test.gel.zone/api/2/clinical-report/illumina/cancer/ILMN-8-1/?reports_v6=true&cip=illumina (note the trailing slash), or set APPEND_SLASH=False in your Django settings.</pre>
<table class="meta">

The urls for Clinical Report posts are now properly generated. However, if applications pass '/' in the last argument as a workaround, this might break their code.