### PR TITLE
Cipapi 899 - adds additional findings consent methods

### DIFF
--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -12,7 +12,7 @@ class CipApiClient(RestClient):
     IG_ENDPOINT = "{url_base}/interpreted-genome".format(url_base=ENDPOINT_BASE)
     REFERRAL_ENDPOINT = "{url_base}/referral".format(url_base=ENDPOINT_BASE)
     FILE_ENDPOINT = "{url_base}/file".format(url_base=ENDPOINT_BASE)
-    AF_ENDPOINT = "{url_base}/participants".format(url_base=ENDPOINT_BASE)
+    PARTICIPANTS_ENDPOINT = "{url_base}/participants".format(url_base=ENDPOINT_BASE)
     PAGE_SIZE_MAX = 500
 
     def __init__(self, url_base, token=None, user=None, password=None, retries=5, fixed_paramters=None):
@@ -153,15 +153,15 @@ class CipApiClient(RestClient):
             yield InterpretationFlag(**flag)
 
     def get_participant_consent_raw(self, participant_id, **params):
-        url = self.build_url(self.url_base, self.AF_ENDPOINT, participant_id, 'consent')
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'consent')
         return self.get(url, params=params)
 
     def post_participant_consent_raw(self, payload, participant_id, **params):
-        url = self.build_url(self.url_base, self.AF_ENDPOINT, participant_id, 'consent') + '/'
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'consent') + '/'
         return self.post(url, payload, params=params)
 
     def put_participant_consent_raw(self, payload, participant_id, **params):
-        url = self.build_url(self.url_base, self.AF_ENDPOINT, participant_id, 'consent') + '/'
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'consent') + '/'
         return self.put(url, payload, params=params)
 
     @returns_item(ParticipantConsent)

--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -1,4 +1,4 @@
-from pycipapi.models import CipApiOverview, CipApiCase, ClinicalReport, Referral, RequestStatus, InterpretationFlag
+from pycipapi.models import CipApiOverview, CipApiCase, ClinicalReport, Referral, RequestStatus, InterpretationFlag, ParticipantConsent
 from pycipapi.rest_client import RestClient, returns_item
 
 
@@ -12,6 +12,7 @@ class CipApiClient(RestClient):
     IG_ENDPOINT = "{url_base}/interpreted-genome".format(url_base=ENDPOINT_BASE)
     REFERRAL_ENDPOINT = "{url_base}/referral".format(url_base=ENDPOINT_BASE)
     FILE_ENDPOINT = "{url_base}/file".format(url_base=ENDPOINT_BASE)
+    AF_ENDPOINT = "{url_base}/participants".format(url_base=ENDPOINT_BASE)
     PAGE_SIZE_MAX = 500
 
     def __init__(self, url_base, token=None, user=None, password=None, retries=5, fixed_paramters=None):
@@ -151,6 +152,10 @@ class CipApiClient(RestClient):
         for flag in flags:
             yield InterpretationFlag(**flag)
 
+    def get_participant_consent_raw(self, participant_id, **params):
+        url = self.build_url(self.url_base, self.AF_ENDPOINT, participant_id, 'consent')
+        return self.get(url, params=params)
+
     @returns_item(InterpretationFlag, multi=True)
     def get_interpretation_flags(self, payload, case_id, case_version, **params):
         """
@@ -158,6 +163,14 @@ class CipApiClient(RestClient):
         :rtype: collections.Iterable[InterpretationFlag]
         """
         return self.get_interpretation_flags_raw(case_id, case_version, **params)
+
+    @returns_item(ParticipantConsent)
+    def get_participant_consent(self, participant_id, **params):
+        """
+
+        :rtype: ParticipantConsent
+        """
+        return self.get_participant_consent_raw(participant_id, **params)
 
 
     @returns_item(CipApiOverview, multi=True)

--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -156,6 +156,38 @@ class CipApiClient(RestClient):
         url = self.build_url(self.url_base, self.AF_ENDPOINT, participant_id, 'consent')
         return self.get(url, params=params)
 
+    def post_participant_consent_raw(self, payload, participant_id, **params):
+        url = self.build_url(self.url_base, self.AF_ENDPOINT, participant_id, 'consent') + '/'
+        return self.post(url, payload, params=params)
+
+    def put_participant_consent_raw(self, payload, participant_id, **params):
+        url = self.build_url(self.url_base, self.AF_ENDPOINT, participant_id, 'consent') + '/'
+        return self.put(url, payload, params=params)
+
+    @returns_item(ParticipantConsent)
+    def get_participant_consent(self, participant_id, **params):
+        """
+        :type participant_id: str
+        :rtype: ParticipantConsent
+        """
+        return self.get_participant_consent_raw(participant_id, **params)
+
+    @returns_item(ParticipantConsent)
+    def post_participant_consent(self, payload, participant_id, **params):
+        """
+        :type participant_id: str
+        :rtype: ParticipantConsent
+        """
+        return self.post_participant_consent_raw(payload, participant_id, **params)
+
+    @returns_item(ParticipantConsent)
+    def put_participant_consent(self, payload, participant_id, **params):
+        """
+        :type participant_id: str
+        :rtype: ParticipantConsent
+        """
+        return self.put_participant_consent_raw(payload, participant_id, **params)
+
     @returns_item(InterpretationFlag, multi=True)
     def get_interpretation_flags(self, payload, case_id, case_version, **params):
         """
@@ -163,15 +195,6 @@ class CipApiClient(RestClient):
         :rtype: collections.Iterable[InterpretationFlag]
         """
         return self.get_interpretation_flags_raw(case_id, case_version, **params)
-
-    @returns_item(ParticipantConsent)
-    def get_participant_consent(self, participant_id, **params):
-        """
-
-        :rtype: ParticipantConsent
-        """
-        return self.get_participant_consent_raw(participant_id, **params)
-
 
     @returns_item(CipApiOverview, multi=True)
     def get_cases(self, **params):

--- a/pycipapi/models.py
+++ b/pycipapi/models.py
@@ -64,7 +64,7 @@ class ReferralTest(object):
         self.interpreter_organisation_national_grouping_name = kwargs.get("interpreter_organisation_national_grouping_name")
         self.interpretation_request_id = kwargs.get("interpretation_request_id")
         self.interpretation_request_version = kwargs.get("interpretation_request_version")
-    
+
     def get_interpretation_request_ids(self):
         return self.interpretation_request_id, self.interpretation_request_version
 
@@ -113,7 +113,7 @@ class Referral(object):
     def get_interpretation_requests_ids(self):
         for rt in self.referral_test:
             yield rt.get_interpretation_request_ids()
-    
+
     def get_interpretation_requests(self, cip_api_client, **params):
         for rt in self.referral_test:
             yield rt.get_interpretation_request(cip_api_client, **params)
@@ -139,6 +139,17 @@ class ExitQuestionnaire(object):
         self.user = kwargs.get('user')
         self.cva_status = kwargs.get('cva_status')
         self.cva_transaction_id = kwargs.get('cva_transaction_id')
+
+
+class ParticipantConsent(object):
+    def __init__(self, **kwargs):
+        self.created_at = kwargs.get('created_at')
+        self.updated_at = kwargs.get('updated_at')
+        self.primary_finding_consent = kwargs.get('primary_finding_consent')
+        self.carrier_status_consent = kwargs.get('carrier_status_consent')
+        self.programme_consent = kwargs.get('programme_consent')
+        self.secondary_finding_consent = kwargs.get('secondary_finding_consent')
+        self.child_consent_form = kwargs.get('child_consent_form')
 
 
 class RequestStatus(object):


### PR DESCRIPTION
Adds additional findings consent methods for GET, POST and PUT that can be used as follows:

`client = CipApiClient()`

* - `client.get_participant_consent(<participant_id>)`
* - `client.post_participant_consent(payload, <participant_id>)`
* - `client.put_participant_consent(payload, <participant_id>)`