### PR TITLE
feat: adds post and get methods for participant clinical reports and int genomes

### DIFF
--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -1,4 +1,14 @@
-from pycipapi.models import CipApiOverview, CipApiCase, ClinicalReport, Referral, RequestStatus, InterpretationFlag, ParticipantConsent
+from pycipapi.models import (
+    CipApiOverview,
+    CipApiCase,
+    ClinicalReport,
+    Referral,
+    RequestStatus,
+    InterpretationFlag,
+    ParticipantConsent,
+    ParticipantInterpretedGenome,
+    ParticipantClinicalReport,
+)
 from pycipapi.rest_client import RestClient, returns_item
 
 
@@ -152,6 +162,18 @@ class CipApiClient(RestClient):
         for flag in flags:
             yield InterpretationFlag(**flag)
 
+    def post_participant_interpreted_genome_raw(self, payload, participant_id, **params):
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'interpreted-genome') + '/'
+        payload_json =  {
+                          "interpreted_genome_data": payload,
+                          "interpretation_service_name": "genomics_england_additional_findings"
+                        }
+        return self.post(url, payload_json, params=params)
+
+    def post_participant_clinical_report_raw(self, payload, participant_id, interpretation_service_name, **params):
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'summary-of-findings','interpretation-service', interpretation_service_name) + '/'
+        return self.post(url, payload, params=params)
+
     def get_participant_consent_raw(self, participant_id, **params):
         url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'consent')
         return self.get(url, params=params)
@@ -172,6 +194,14 @@ class CipApiClient(RestClient):
         """
         return self.get_participant_consent_raw(participant_id, **params)
 
+    @returns_item(ParticipantClinicalReport)
+    def post_participant_clinical_report(self, payload, participant_id,interpretation_service_name, **params):
+        """
+        :type participant_id: str
+        :rtype: ParticipantClinicalReport
+        """
+        return self.post_participant_clinical_report_raw(payload, participant_id, interpretation_service_name, **params)
+
     @returns_item(ParticipantConsent)
     def post_participant_consent(self, payload, participant_id, **params):
         """
@@ -187,6 +217,14 @@ class CipApiClient(RestClient):
         :rtype: ParticipantConsent
         """
         return self.put_participant_consent_raw(payload, participant_id, **params)
+
+    @returns_item(ParticipantInterpretedGenome)
+    def post_participant_interpreted_genome(self, payload, participant_id, **params):
+        """
+        :type participant_id: str
+        :rtype: ParticipantInterpretedGenome
+        """
+        return self.post_participant_interpreted_genome_raw(payload, participant_id, **params)
 
     @returns_item(InterpretationFlag, multi=True)
     def get_interpretation_flags(self, payload, case_id, case_version, **params):

--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -186,6 +186,14 @@ class CipApiClient(RestClient):
         url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'consent') + '/'
         return self.put(url, payload, params=params)
 
+    def get_participant_interpreted_genome_raw(self, participant_id, interpretation_service_name, version, **params):
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'interpreted-genome', interpretation_service_name, version) + '/'
+        return self.get(url, params=params)
+
+    def get_participant_clinical_report_raw(self, participant_id, version, **params):
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'summary-of-findings', version) + '/'
+        return self.get(url, params=params)
+
     @returns_item(ParticipantConsent)
     def get_participant_consent(self, participant_id, **params):
         """
@@ -193,6 +201,14 @@ class CipApiClient(RestClient):
         :rtype: ParticipantConsent
         """
         return self.get_participant_consent_raw(participant_id, **params)
+
+    @returns_item(ParticipantClinicalReport)
+    def get_participant_clinical_report(self, participant_id, version, **params):
+        """
+        :type participant_id: str
+        :rtype: ParticipantClinicalReport
+        """
+        return self.get_participant_clinical_report_raw(participant_id, version, **params)
 
     @returns_item(ParticipantClinicalReport)
     def post_participant_clinical_report(self, payload, participant_id,interpretation_service_name, **params):
@@ -225,6 +241,14 @@ class CipApiClient(RestClient):
         :rtype: ParticipantInterpretedGenome
         """
         return self.post_participant_interpreted_genome_raw(payload, participant_id, **params)
+
+    @returns_item(ParticipantInterpretedGenome)
+    def get_participant_interpreted_genome(self, participant_id, interpretation_service_name, version, **params):
+        """
+        :type participant_id: str
+        :rtype: ParticipantInterpretedGenome
+        """
+        return self.get_participant_interpreted_genome_raw(participant_id, interpretation_service_name, version, **params)
 
     @returns_item(InterpretationFlag, multi=True)
     def get_interpretation_flags(self, payload, case_id, case_version, **params):

--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -162,11 +162,11 @@ class CipApiClient(RestClient):
         for flag in flags:
             yield InterpretationFlag(**flag)
 
-    def post_participant_interpreted_genome_raw(self, payload, participant_id, **params):
+    def post_participant_interpreted_genome_raw(self, payload, participant_id, interpretation_service_name = 'genomics_england_additional_findings', **params):
         url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'interpreted-genome') + '/'
         payload_json =  {
                           "interpreted_genome_data": payload,
-                          "interpretation_service_name": "genomics_england_additional_findings"
+                          "interpretation_service_name": interpretation_service_name
                         }
         return self.post(url, payload_json, params=params)
 
@@ -194,12 +194,12 @@ class CipApiClient(RestClient):
         url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'summary-of-findings', version) + '/'
         return self.get(url, params=params)
 
-    def list_participant_interpreted_genome_raw(self, participant_id, **params):
+    def list_participant_interpreted_genomes_raw(self, participant_id, **params):
         url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'interpreted-genome') + '/'
         for r in self.get_paginated(url, params=params):
             yield r
 
-    def list_participant_clinical_report_raw(self, participant_id, **params):
+    def list_participant_clinical_reports_raw(self, participant_id, **params):
         url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'summary-of-findings') + '/'
         for r in self.get_paginated(url, params=params):
             yield r
@@ -229,12 +229,12 @@ class CipApiClient(RestClient):
         return self.post_participant_clinical_report_raw(payload, participant_id, interpretation_service_name, **params)
 
     @returns_item(ParticipantClinicalReport, multi=True)
-    def list_participant_clinical_report(self, participant_id, **params):
+    def list_participant_clinical_reports(self, participant_id, **params):
         """
 
         :rtype: collections.Iterable[ParticipantClinicalReport]
         """
-        return self.list_participant_clinical_report_raw(participant_id, **params)
+        return self.list_participant_clinical_reports_raw(participant_id, **params)
 
     @returns_item(ParticipantConsent)
     def post_participant_consent(self, payload, participant_id, **params):
@@ -269,12 +269,12 @@ class CipApiClient(RestClient):
         return self.get_participant_interpreted_genome_raw(participant_id, interpretation_service_name, version, **params)
 
     @returns_item(ParticipantInterpretedGenome, multi=True)
-    def list_participant_interpreted_genome(self, participant_id, **params):
+    def list_participant_interpreted_genomes(self, participant_id, **params):
         """
 
         :rtype: collections.Iterable[ParticipantInterpretedGenome]
         """
-        return self.list_participant_interpreted_genome_raw(participant_id, **params)
+        return self.list_participant_interpreted_genomes_raw(participant_id, **params)
 
     @returns_item(InterpretationFlag, multi=True)
     def get_interpretation_flags(self, payload, case_id, case_version, **params):

--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -194,6 +194,16 @@ class CipApiClient(RestClient):
         url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'summary-of-findings', version) + '/'
         return self.get(url, params=params)
 
+    def list_participant_interpreted_genome_raw(self, participant_id, **params):
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'interpreted-genome') + '/'
+        for r in self.get_paginated(url, params=params):
+            yield r
+
+    def list_participant_clinical_report_raw(self, participant_id, **params):
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'summary-of-findings') + '/'
+        for r in self.get_paginated(url, params=params):
+            yield r
+
     @returns_item(ParticipantConsent)
     def get_participant_consent(self, participant_id, **params):
         """
@@ -217,6 +227,14 @@ class CipApiClient(RestClient):
         :rtype: ParticipantClinicalReport
         """
         return self.post_participant_clinical_report_raw(payload, participant_id, interpretation_service_name, **params)
+
+    @returns_item(ParticipantClinicalReport, multi=True)
+    def list_participant_clinical_report(self, participant_id, **params):
+        """
+
+        :rtype: collections.Iterable[ParticipantClinicalReport]
+        """
+        return self.list_participant_clinical_report_raw(participant_id, **params)
 
     @returns_item(ParticipantConsent)
     def post_participant_consent(self, payload, participant_id, **params):
@@ -249,6 +267,14 @@ class CipApiClient(RestClient):
         :rtype: ParticipantInterpretedGenome
         """
         return self.get_participant_interpreted_genome_raw(participant_id, interpretation_service_name, version, **params)
+
+    @returns_item(ParticipantInterpretedGenome, multi=True)
+    def list_participant_interpreted_genome(self, participant_id, **params):
+        """
+
+        :rtype: collections.Iterable[ParticipantInterpretedGenome]
+        """
+        return self.list_participant_interpreted_genome_raw(participant_id, **params)
 
     @returns_item(InterpretationFlag, multi=True)
     def get_interpretation_flags(self, payload, case_id, case_version, **params):

--- a/pycipapi/models.py
+++ b/pycipapi/models.py
@@ -152,6 +152,26 @@ class ParticipantConsent(object):
         self.child_consent_form = kwargs.get('child_consent_form')
 
 
+class ParticipantInterpretedGenome(object):
+    def __init__(self, **kwargs):
+        self.created_at = kwargs.get('created_at')
+        self.version = kwargs.get('version')
+        self.interpreted_genome_data = kwargs.get('interpreted_genome_data')
+        self.interpretation_service_name = kwargs.get('interpretation_service_name')
+        self.result_summary = kwargs.get('result_summary')
+
+
+class ParticipantClinicalReport(object):
+    def __init__(self, **kwargs):
+        self.clinical_report_version = kwargs.get('clinical_report_version')
+        self.clinical_report_data = kwargs.get('clinical_report_data')
+        self.created_at = kwargs.get('created_at')
+        self.draft = kwargs.get('draft')
+        self.exit_questionnaire = ExitQuestionnaire(**kwargs.get('exit_questionnaire')) if\
+            kwargs.get('exit_questionnaire') else None
+        self.timestamp = kwargs.get('timestamp')
+
+
 class RequestStatus(object):
     def __init__(self, **kwargs):
         self.created_at = kwargs.get('created_at')

--- a/pycipapi/models.py
+++ b/pycipapi/models.py
@@ -140,6 +140,12 @@ class ExitQuestionnaire(object):
         self.cva_status = kwargs.get('cva_status')
         self.cva_transaction_id = kwargs.get('cva_transaction_id')
 
+class ParticipantExitQuestionnaire(object):
+    def __init__(self, **kwargs):
+        self.created_at = kwargs.get('created_at')
+        self.exit_questionnaire_data = kwargs.get('exit_questionnaire_data')
+        self.user = kwargs.get('user')
+        self.draft = kwargs.get('draft')
 
 class ParticipantConsent(object):
     def __init__(self, **kwargs):
@@ -167,7 +173,7 @@ class ParticipantClinicalReport(object):
         self.clinical_report_data = kwargs.get('clinical_report_data')
         self.created_at = kwargs.get('created_at')
         self.draft = kwargs.get('draft')
-        self.exit_questionnaire = ExitQuestionnaire(**kwargs.get('exit_questionnaire')) if\
+        self.exit_questionnaire = ParticipantExitQuestionnaire(**kwargs.get('exit_questionnaire')) if\
             kwargs.get('exit_questionnaire') else None
         self.timestamp = kwargs.get('timestamp')
 


### PR DESCRIPTION
Methods for posting participant interpreted genomes and participant clinical reports (Participant Consent needs to be posted first) as follows:

`CipapiClient().get_participant_interpreted_genome(participant_id, interpretation_service_name, version)`
`CipapiClient().list_participant_interpreted_genomes(participant_id)`
`CipapiClient().post_participant_interpreted_genome(payload, participant_id)`

`CipapiClient().get_participant_clinical_report(participant_id, version, interpretation_service_name= ''genomics_england_additional_findings")`
`CipapiClient().list_participant_clinical_reports(participant_id)`
`CipapiClient().post_participant_clinical_report(payload, participant_id, interpretation_service_name)`

closes CIPAPI-921