### PR TITLE
AF-198 added method to list participants endpoint query

### DIFF
--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -6,6 +6,7 @@ from pycipapi.models import (
     Referral,
     RequestStatus,
     InterpretationFlag,
+    Participant,
     ParticipantConsent,
     ParticipantInterpretedGenome,
     ParticipantClinicalReport,
@@ -180,7 +181,7 @@ class CipApiClient(RestClient):
         return self.post(url, payload_json, params=params)
 
     def post_participant_clinical_report_raw(self, payload, participant_id, interpretation_service_name, **params):
-        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'summary-of-findings','interpretation-service', interpretation_service_name) + '/'
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'summary-of-findings', 'interpretation-service', interpretation_service_name) + '/'
         return self.post(url, payload, params=params)
 
     def get_participant_consent_raw(self, participant_id, **params):
@@ -202,6 +203,11 @@ class CipApiClient(RestClient):
     def get_participant_clinical_report_raw(self, participant_id, version, **params):
         url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'summary-of-findings', version) + '/'
         return self.get(url, params=params)
+
+    def list_participants_raw(self, **params):
+        url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT) + '/'
+        for r in self.get_paginated(url, **params):
+            yield r
 
     def list_participant_interpreted_genomes_raw(self, participant_id, **params):
         url = self.build_url(self.url_base, self.PARTICIPANTS_ENDPOINT, participant_id, 'interpreted-genome') + '/'
@@ -346,6 +352,16 @@ class CipApiClient(RestClient):
     @returns_item(RequestStatus, multi=False)
     def submit_interpreted_genome(self, payload, partner_id, analysis_type, report_id, **params):
         return self.submit_interpreted_genome_raw(payload, partner_id, analysis_type, report_id, **params)
+
+    @returns_item(Participant, multi=True)
+    def list_participants(self, **params):
+        """
+        This method lists all the participants registered in cipapi, filtered by given params.
+
+        :param params:
+        :return: Participant
+        """
+        return self.list_participants_raw(**params)
 
     @returns_item(ClinicalReport, multi=True)
     def list_clinical_reports(self, **params):

--- a/pycipapi/models.py
+++ b/pycipapi/models.py
@@ -146,12 +146,38 @@ class ExitQuestionnaire(object):
         self.cva_status = kwargs.get('cva_status')
         self.cva_transaction_id = kwargs.get('cva_transaction_id')
 
+
+class Participant:
+    def __init__(self, **kwargs):
+        self.participant_id = kwargs.get('participant_id')
+        self.participant_uid = kwargs.get('participant_uid')
+        self.family_id = kwargs.get('family_id')
+        self.sample_ids = kwargs.get('sample_ids')
+        self.interpretation_request = kwargs.get('interpretation_request')
+        self.category = kwargs.get('category')
+        self.participant_interpreted_genome = [ParticipantInterpretedGenome(**ig) for ig in kwargs.get('participant_interpreted_genome', [])]
+        self.participant_clinical_report = kwargs.get("participant_clinical_report")
+        self.primary_findings_analysis = kwargs.get("primary_findings_analysis")
+        self.additional_findings_analysis = kwargs.get("additional_findings_analysis")
+        self.year_of_birth = kwargs.get("year_of_birth")
+        self.assembly = kwargs.get("assembly")
+        self.sex = kwargs.get("sex")
+        self.clinical_indication = kwargs.get("clinical_indication")
+        self.created_at = kwargs.get("created_at")
+        self.updated_at = kwargs.get("updated_at")
+        self.participant_consent = ParticipantConsent(**kwargs.get("participant_consent")) if kwargs.get("participant_consent") else None
+        self.sites = kwargs.get("sites")
+        self.sample_type = kwargs.get("sample_type")
+        self.additional_findings_status = kwargs.get("additional_findings_status")
+
+
 class ParticipantExitQuestionnaire(object):
     def __init__(self, **kwargs):
         self.created_at = kwargs.get('created_at')
         self.exit_questionnaire_data = kwargs.get('exit_questionnaire_data')
         self.user = kwargs.get('user')
         self.draft = kwargs.get('draft')
+
 
 class ParticipantConsent(object):
     def __init__(self, **kwargs):
@@ -513,7 +539,6 @@ class CipApiOverview(object):
         self.status = [RequestStatus(**s) for s in kwargs.get('status', [])]
         self.referral = Referral(**kwargs.get('referral')) if kwargs.get('referral') else None
         self.interpretation_flags = kwargs.get('interpretation_flags')
-
 
     def get_case(self, cip_api_client, **params):
         """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pycipapi',
-    version='0.11.0',
+    version='0.12.0',
     packages=find_packages(),
     scripts=[],
     url='https://github.com/genomicsengland/pycipapi',


### PR DESCRIPTION
There is a participants endpoint that enables users to query and filter from all participants.

I've added a method to query said endpoint.

It can be used like so:
`cipapi_client.list_participants(additional_findings_status="not_applicable", participant_id="XXX")`

or like so:
`cipapi_client.list_participants(**{"additional_findings_status": "closed", "sex": "MALE"})`
