### PR TITLE
fix: submit int request method changes params passed to patch method

### DIFF
--- a/pycipapi/cipapi_client.py
+++ b/pycipapi/cipapi_client.py
@@ -114,7 +114,7 @@ class CipApiClient(RestClient):
                                           **params):
         payload = {"interpretation_request_data": {"json_request": interpretation_request_dict}}
         payload.update(extra_fields)
-        return self.patch_case_raw(case_id, case_version, payload, params=params)
+        return self.patch_case_raw(case_id, case_version, payload, **params)
 
     def dispatch_raw(self, case_id, case_version, **params):
         url = self.build_url(self.url_base, self.IR_ENDPOINT, 'dispatch', case_id, case_version) + '/'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pycipapi',
-    version='0.12.0',
+    version='0.12.1',
     packages=find_packages(),
     scripts=[],
     url='https://github.com/genomicsengland/pycipapi',


### PR DESCRIPTION
`submit_interpretation_request_method` alters `params` passed into `patch_case_raw` method and it doesn't work the same way as `patch_case` does
small fix so only changing the minor version